### PR TITLE
Add service worker caching for pixel script

### DIFF
--- a/functions/pixel.js
+++ b/functions/pixel.js
@@ -10,6 +10,9 @@ export default {
 
     const js = `(function(){
   try {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js');
+    }
     const c="${cid}", _r = localStorage.getItem("_r") || crypto.randomUUID();
     localStorage.setItem("_r", _r);
     document.cookie = "_r=" + _r + ";path=/;max-age=2592000;SameSite=Lax";

--- a/functions/sw.js
+++ b/functions/sw.js
@@ -1,0 +1,38 @@
+const sw = `
+const CACHE_NAME = 'pixel-cache-v1';
+const RESOURCES = ['/pixel'];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(RESOURCES))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+  if (url.pathname.startsWith('/pixel')) {
+    event.respondWith((async () => {
+      const cache = await caches.open(CACHE_NAME);
+      const cached = await cache.match(event.request);
+      const network = fetch(event.request).then(res => {
+        cache.put(event.request, res.clone());
+        return res;
+      });
+      event.waitUntil(network);
+      return cached || network;
+    })());
+  }
+});
+`;
+
+export default {
+  async fetch() {
+    return new Response(sw, {
+      headers: {
+        'Content-Type': 'application/javascript',
+        'Cache-Control': 'no-cache, no-store, must-revalidate'
+      }
+    });
+  }
+};

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ import log from "./functions/log.js";
 import serve from "./functions/serve.js";
 import r from "./functions/r.js";
 import pixel from "./functions/pixel.js";
+import sw from "./functions/sw.js";
 
 export default {
   async fetch(request, env, ctx) {
@@ -11,6 +12,7 @@ export default {
     // Fixed route handlers
     if (path === "/log") return log.fetch(request, env, ctx);
     if (path === "/serve") return serve.fetch(request, env, ctx);
+    if (path === "/sw.js") return sw.fetch(request, env, ctx);
 
     // Dynamic campaign handlers
     if (path.startsWith("/pixel")) return pixel.fetch(request, env, ctx);


### PR DESCRIPTION
## Summary
- Register a service worker from the pixel script to enable offline caching
- Serve a new `sw.js` that caches `/pixel` requests and refreshes them in the background
- Route `/sw.js` through the worker for proper delivery

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b6e3a3eea08323a088070e88e9d5f3