### PR TITLE
Verify service worker availability before registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/functions/pixel.js
+++ b/functions/pixel.js
@@ -11,7 +11,13 @@ export default {
     const js = `(function(){
   try {
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js');
+      fetch('/sw.js', { cache: 'no-store' })
+        .then(res => {
+          const type = res.headers.get('content-type') || '';
+          if (res.ok && type.includes('javascript')) {
+            navigator.serviceWorker.register('/sw.js');
+          }
+        });
     }
     const c="${cid}", _r = localStorage.getItem("_r") || crypto.randomUUID();
     localStorage.setItem("_r", _r);

--- a/functions/sw.js
+++ b/functions/sw.js
@@ -29,6 +29,7 @@ self.addEventListener('fetch', event => {
 export default {
   async fetch() {
     return new Response(sw, {
+      status: 200,
       headers: {
         'Content-Type': 'application/javascript',
         'Cache-Control': 'no-cache, no-store, must-revalidate'


### PR DESCRIPTION
## Summary
- Serve `/sw.js` with explicit `200` status and JavaScript MIME type
- Ensure pixel script fetches and validates `/sw.js` before registering the service worker
- Ignore `node_modules` in version control

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68b83da3dd248323b3b62d50499bcf1e