### PR TITLE
Add error handling for missing pixel script

### DIFF
--- a/functions/pixel.js
+++ b/functions/pixel.js
@@ -10,6 +10,11 @@ export default {
     const url = new URL(request.url);
     const cid = url.searchParams.get("cid") || "default";
 
-    return new Response(js.replace("__CID__", cid), { status: 200, headers });
+    try {
+      const body = js.replace("__CID__", cid);
+      return new Response(body, { status: 200, headers });
+    } catch (err) {
+      return new Response("Failed to load pixel script", { status: 500, headers });
+    }
   }
 };


### PR DESCRIPTION
## Summary
- handle missing pixel script with 500 response instead of crashing

## Testing
- `npx wrangler --version` *(fails: 403 Forbidden to npm registry)*
- `npm run build` *(fails: esbuild: not found)*
- `npm install` *(fails: 403 Forbidden to npm registry)*

------
https://chatgpt.com/codex/tasks/task_b_68b9770419548323b9c849687b1f215f