### PR TITLE
Add pre-deploy check for client pixel bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Aggressive stealth attribution system powered by Cloudflare Workers",
   "scripts": {
     "build": "esbuild client/pixel.js --bundle --minify --outfile=client/pixel.min.js",
-    "deploy": "npm run build && npx wrangler deploy"
+    "check:client": "node scripts/check-pixel.js",
+    "deploy": "npm run build && npm run check:client && npx wrangler deploy"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.50.0",

--- a/scripts/check-pixel.js
+++ b/scripts/check-pixel.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const file = path.join(__dirname, '..', 'client', 'pixel.min.js');
+if (!fs.existsSync(file)) {
+  console.error('Missing client/pixel.min.js. Run npm run build to generate it.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add script to ensure `client/pixel.min.js` exists
- run pixel bundle check before deploying

## Testing
- `npm run build`
- `npm run check:client`
- `rm client/pixel.min.js && npm run check:client` *(fails: Missing client/pixel.min.js. Run npm run build to generate it.)*


------
https://chatgpt.com/codex/tasks/task_b_68b97aab47c083239fe8ca38058d666d