### PR TITLE
Configure text loader for pixel script

### DIFF
--- a/functions/pixel.js
+++ b/functions/pixel.js
@@ -1,4 +1,4 @@
-import js from "../client/pixel.min.js?raw";
+import js from "../client/pixel.min.js";
 
 export default {
   async fetch(request) {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,3 +10,7 @@ routes = [
   { pattern = "retarglow.com/r*", zone_name = "retarglow.com" },
   { pattern = "retarglow.com/pixel*", zone_name = "retarglow.com" }
 ]
+
+[[rules]]
+type = "Text"
+globs = ["client/pixel.min.js"]


### PR DESCRIPTION
## Summary
- load pixel script as text without `?raw`
- configure Wrangler to treat `client/pixel.min.js` as text for bundling

## Testing
- `npm run build`
- `npx wrangler deploy --dry-run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/wrangler)*

------
https://chatgpt.com/codex/tasks/task_b_68b97ad362b483239a9aae2d23c63bc7