### PR TITLE
Handle missing pixel asset gracefully

### DIFF
--- a/functions/pixel.js
+++ b/functions/pixel.js
@@ -1,4 +1,7 @@
-import js from "../client/pixel.min.js";
+import { readFileSync } from "node:fs";
+
+// Read the pixel asset at build time so deployment fails fast if missing
+const js = readFileSync(new URL("../client/pixel.min.js", import.meta.url), "utf8");
 
 export default {
   async fetch(request) {
@@ -11,10 +14,15 @@ export default {
     const cid = url.searchParams.get("cid") || "default";
 
     try {
+      if (typeof js !== "string") {
+        throw new Error("Pixel script missing");
+      }
+
       const body = js.replace("__CID__", cid);
       return new Response(body, { status: 200, headers });
     } catch (err) {
-      return new Response("Failed to load pixel script", { status: 500, headers });
+      const fallback = "console.error('Failed to load pixel script');";
+      return new Response(fallback, { status: 500, headers });
     }
   }
 };


### PR DESCRIPTION
## Summary
- Load pixel script via `fs.readFileSync` so deploys fail if the asset is missing
- Ensure the pixel script is a string before injecting the campaign ID
- Return a 500 with a fallback script when the pixel asset can't be served

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check:client`


------
https://chatgpt.com/codex/tasks/task_b_68b97edddb0083239cca21cb240d87b8