### PR TITLE
Remove deprecated cookie assignments from pixel client

### DIFF
--- a/functions/client/pixel-client.js
+++ b/functions/client/pixel-client.js
@@ -10,8 +10,6 @@ export const PIXEL_CLIENT_SOURCE = String.raw`(function () {
       window.__RETARGLOW_PIXEL__._r = _r;
     }
     document.cookie = "_r=" + _r + ";path=/;max-age=2592000;SameSite=Lax";
-    document.cookie = "smc_uid=" + _r + ";path=/;max-age=31536000;SameSite=Lax";
-    document.cookie = "user_id_t=" + _r + ";path=/;max-age=31536000;SameSite=Lax";
 
     let vc = 1;
     try {


### PR DESCRIPTION
## Summary
- remove the extra smc_uid and user_id_t cookie writes from the pixel client script so only _r is set

## Testing
- node --input-type=module - <<'NODE'
import pixel from './functions/pixel.js';
const request = new Request('https://example.com/pixel?cid=test-client');
const response = await pixel.fetch(request);
console.log('status', response.status);
const text = await response.text();
console.log(text);
NODE

------
https://chatgpt.com/codex/tasks/task_b_68dade63e4488323a8c4610f8e79c858