### PR TITLE
Ensure bootstrap frame URL includes token

### DIFF
--- a/functions/__tests__/b.test.js
+++ b/functions/__tests__/b.test.js
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+const supabaseModule = await import("../lib/supabase.js");
+const workerModule = await import("../b.js");
+
+async function withSupabaseStub(stub, fn) {
+  const originalFrom = supabaseModule.supabase.from;
+  supabaseModule.supabase.from = stub;
+  try {
+    await fn();
+  } finally {
+    supabaseModule.supabase.from = originalFrom;
+  }
+}
+
+test("bootstrap response includes frame_src with token when ad plan found", { concurrency: false }, async () => {
+  const eventsLogged = [];
+
+  await withSupabaseStub((table) => {
+    if (table === "campaigns") {
+      return {
+        select: () => ({
+          order: async () => ({
+            data: [
+              {
+                id: "cmp-123",
+                status: true,
+                ad_url: "https://ads.example.com/render?rid={{_r}}",
+                iframe_width: 320,
+                iframe_height: 50,
+                iframe_style: "border:0;",
+                iframe_attributes: { allow: "autoplay" }
+              }
+            ],
+            error: null
+          })
+        })
+      };
+    }
+
+    if (table === "events") {
+      return {
+        insert: async (rows) => {
+          eventsLogged.push(...rows);
+          return { error: null };
+        }
+      };
+    }
+
+    throw new Error(`Unexpected table: ${table}`);
+  }, async () => {
+    const request = new Request("https://bootstrap.example.com/api", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Origin: "https://bootstrap.example.com",
+        Cookie: "",
+        "user-agent": "Mozilla/5.0",
+        "cf-connecting-ip": "203.0.113.1",
+        "cf-ipcountry": "US"
+      },
+      body: JSON.stringify({})
+    });
+
+    const env = { SIGNING_SECRET: "test-secret" };
+
+    const response = await workerModule.default.fetch(request, env, {
+      waitUntil: () => {}
+    });
+
+    assert.equal(response.status, 200);
+    const json = await response.json();
+
+    assert.equal(json.success, true);
+    assert.equal(typeof json.token, "string");
+    assert(json.token.length > 0);
+    assert.equal(typeof json.frame_src, "string");
+    assert(json.frame_src.includes("?token="));
+
+    const frameUrl = new URL(json.frame_src);
+    assert.equal(frameUrl.origin, "https://bootstrap.example.com");
+    assert.equal(frameUrl.pathname, "/frame");
+    assert.equal(frameUrl.searchParams.get("token"), json.token);
+
+    assert(eventsLogged.length > 0);
+  });
+});
+
+test("bootstrap response omits frame_src when token is not generated", { concurrency: false }, async () => {
+  await withSupabaseStub((table) => {
+    if (table === "campaigns") {
+      return {
+        select: () => ({
+          order: async () => ({
+            data: [],
+            error: null
+          })
+        })
+      };
+    }
+
+    if (table === "events") {
+      return {
+        insert: async () => ({ error: null })
+      };
+    }
+
+    throw new Error(`Unexpected table: ${table}`);
+  }, async () => {
+    const request = new Request("https://bootstrap.example.com/api", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Origin: "https://bootstrap.example.com",
+        Cookie: "",
+        "user-agent": "Mozilla/5.0",
+        "cf-connecting-ip": "203.0.113.1",
+        "cf-ipcountry": "US"
+      },
+      body: JSON.stringify({})
+    });
+
+    const env = { SIGNING_SECRET: "test-secret" };
+
+    const response = await workerModule.default.fetch(request, env, {
+      waitUntil: () => {}
+    });
+
+    assert.equal(response.status, 200);
+    const json = await response.json();
+
+    assert.equal(json.success, true);
+    assert.equal(json.token, null);
+    assert.equal("frame_src" in json, false);
+  });
+});

--- a/functions/b.js
+++ b/functions/b.js
@@ -359,9 +359,12 @@ export default {
 
     const responseBody = {
       success: true,
-      token,
-      frame_src: `${frameOrigin}/frame`
+      token
     };
+
+    if (token) {
+      responseBody.frame_src = `${frameOrigin}/frame?token=${encodeURIComponent(token)}`;
+    }
 
     return new Response(JSON.stringify(responseBody), {
       status: 200,


### PR DESCRIPTION
## Summary
- build the bootstrap frame URL only after a token is generated, embedding the token in the query string
- omit the frame URL when no token is produced so the client does not load an unusable frame
- add integration-style tests to confirm the response includes a fully qualified frame URL with the token

## Testing
- node --test functions/__tests__/b.test.js

------
https://chatgpt.com/codex/tasks/task_b_68e38d2e760c8323b61343fdd8de564e