### PR TITLE
Handle bigint campaign ids when signing bootstrap tokens

### DIFF
--- a/functions/b.js
+++ b/functions/b.js
@@ -119,8 +119,17 @@ async function selectAdPlan(pageUrl = "", retargetId) {
         : null;
       if (!adUrl) continue;
 
+      let campaignId = null;
+      if (row?.id != null) {
+        try {
+          campaignId = String(row.id);
+        } catch (err) {
+          campaignId = null;
+        }
+      }
+
       return {
-        campaignId: row.id || null,
+        campaignId,
         src: adUrl,
         width: row.iframe_width ?? 0,
         height: row.iframe_height ?? 0,


### PR DESCRIPTION
## Summary
- convert campaign identifiers to strings before serialising and signing bootstrap payloads to avoid BigInt JSON errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68dfdccac5e88323881a7ac01d26bf4a