### PR TITLE
Prevent BigInt fields from breaking bootstrap token signing

### DIFF
--- a/functions/__tests__/b.test.js
+++ b/functions/__tests__/b.test.js
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { verifyToken } from "../lib/token.js";
+
 const supabaseModule = await import("../lib/supabase.js");
 const workerModule = await import("../b.js");
 
@@ -133,5 +135,68 @@ test("bootstrap response omits frame_src when token is not generated", { concurr
     assert.equal(json.success, true);
     assert.equal(json.token, null);
     assert.equal("frame_src" in json, false);
+  });
+});
+
+test("bootstrap token payload normalizes bigint values", { concurrency: false }, async () => {
+  await withSupabaseStub((table) => {
+    if (table === "campaigns") {
+      return {
+        select: () => ({
+          order: async () => ({
+            data: [
+              {
+                id: 987654321n,
+                status: true,
+                ad_url: "https://ads.example.com/render?rid={{_r}}",
+                iframe_width: 728n,
+                iframe_height: 90n,
+                iframe_style: "border:0;",
+                iframe_attributes: {
+                  allow: "autoplay",
+                  "data-campaign": 555n
+                }
+              }
+            ],
+            error: null
+          })
+        })
+      };
+    }
+
+    if (table === "events") {
+      return {
+        insert: async () => ({ error: null })
+      };
+    }
+
+    throw new Error(`Unexpected table: ${table}`);
+  }, async () => {
+    const request = new Request("https://bootstrap.example.com/api", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Origin: "https://bootstrap.example.com",
+        Cookie: ""
+      },
+      body: JSON.stringify({})
+    });
+
+    const env = { SIGNING_SECRET: "test-secret" };
+
+    const response = await workerModule.default.fetch(request, env, {
+      waitUntil: () => {}
+    });
+
+    assert.equal(response.status, 200);
+    const json = await response.json();
+    assert.equal(json.success, true);
+    assert.equal(typeof json.token, "string");
+
+    const payload = await verifyToken(env, json.token);
+    assert.equal(payload.plan.campaignId, "987654321");
+    assert.equal(payload.plan.width, 728);
+    assert.equal(payload.plan.height, 90);
+    assert.equal(payload.plan.attributes["data-campaign"], "555");
   });
 });

--- a/functions/b.js
+++ b/functions/b.js
@@ -4,6 +4,72 @@ import { base64UrlEncode, encodeToken } from "./lib/token.js";
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // one year
 const TOKEN_TTL_SECONDS = 60 * 5; // five minutes
 
+function normalizeForJson(value) {
+  if (typeof value === "bigint") {
+    const asNumber = Number(value);
+    return Number.isSafeInteger(asNumber) ? asNumber : value.toString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeForJson);
+  }
+
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value);
+    const normalized = {};
+    for (const [key, val] of entries) {
+      if (val === undefined) continue;
+      normalized[key] = normalizeForJson(val);
+    }
+    return normalized;
+  }
+
+  return value;
+}
+
+function normalizeDimension(value) {
+  if (value == null) return 0;
+
+  if (typeof value === "bigint") {
+    const asNumber = Number(value);
+    if (Number.isSafeInteger(asNumber)) return asNumber;
+    return Number.parseInt(value.toString(), 10);
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+
+  return 0;
+}
+
+function normalizeAttributes(attributes) {
+  if (!attributes || typeof attributes !== "object") {
+    return {};
+  }
+
+  const normalized = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (!key) continue;
+    if (value == null) continue;
+
+    if (typeof value === "bigint") {
+      normalized[key] = value.toString();
+    } else if (typeof value === "boolean" || typeof value === "number") {
+      normalized[key] = String(value);
+    } else {
+      normalized[key] = String(value);
+    }
+  }
+
+  return normalized;
+}
+
 function generateNonce() {
   if (typeof crypto !== "undefined" && crypto.getRandomValues) {
     const bytes = new Uint8Array(16);
@@ -119,19 +185,29 @@ async function selectAdPlan(pageUrl = "", retargetId) {
         : null;
       if (!adUrl) continue;
 
+      let campaignId = null;
+      if (row?.id != null) {
+        try {
+          campaignId = String(row.id);
+        } catch (err) {
+          campaignId = null;
+        }
+      }
+
       return {
-        campaignId: row.id || null,
+        campaignId,
         src: adUrl,
-        width: row.iframe_width ?? 0,
-        height: row.iframe_height ?? 0,
+        width: normalizeDimension(row.iframe_width),
+        height: normalizeDimension(row.iframe_height),
         style:
-          row.iframe_style ||
-          "position:fixed;top:-9999px;left:-9999px;width:1px;height:1px;opacity:0;border:0;",
+          typeof row.iframe_style === "string" && row.iframe_style.length > 0
+            ? row.iframe_style
+            : "position:fixed;top:-9999px;left:-9999px;width:1px;height:1px;opacity:0;border:0;",
         attributes: {
           referrerpolicy: "no-referrer",
           scrolling: "no",
           frameborder: "0",
-          ...(row.iframe_attributes || {})
+          ...normalizeAttributes(row.iframe_attributes)
         }
       };
     }
@@ -266,7 +342,7 @@ export default {
     let token = null;
     if (adPlan) {
       try {
-        const payload = {
+        const payload = normalizeForJson({
           nonce: generateNonce(),
           exp: Math.floor(Date.now() / 1000) + TOKEN_TTL_SECONDS,
           plan: {
@@ -277,7 +353,7 @@ export default {
             style: adPlan.style,
             attributes: adPlan.attributes
           }
-        };
+        });
         token = await encodeToken(env, payload);
       } catch (err) {
         console.error("token signing error", err);


### PR DESCRIPTION
## Summary
- normalize campaign plan dimensions and attributes before generating bootstrap tokens
- recursively convert plan payloads to JSON-safe types prior to signing so BigInts no longer trigger 500 errors
- add regression coverage proving BigInt plan data produces a signed token successfully

## Testing
- node --test functions/__tests__/b.test.js
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68dfdccac5e88323881a7ac01d26bf4a