### PR TITLE
Improve campaign domain matching for bootstrap selection

### DIFF
--- a/functions/__tests__/b.test.js
+++ b/functions/__tests__/b.test.js
@@ -89,6 +89,120 @@ test("bootstrap response includes frame_src with token when ad plan found", { co
   });
 });
 
+test("bootstrap matches campaigns by domain rule on subdomains", { concurrency: false }, async () => {
+  await withSupabaseStub((table) => {
+    if (table === "campaigns") {
+      return {
+        select: () => ({
+          order: async () => ({
+            data: [
+              {
+                id: "cmp-789",
+                status: true,
+                audience_rules: { domain: "publisher.example" },
+                ad_url: "https://ads.example.com/render?rid={{_r}}",
+                iframe_width: 728,
+                iframe_height: 90,
+                iframe_style: null,
+                iframe_attributes: null
+              }
+            ],
+            error: null
+          })
+        })
+      };
+    }
+
+    if (table === "events") {
+      return {
+        insert: async () => ({ error: null })
+      };
+    }
+
+    throw new Error(`Unexpected table: ${table}`);
+  }, async () => {
+    const payload = { u: "https://sub.publisher.example/articles?id=1" };
+    const request = new Request("https://bootstrap.example.com/api", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Origin: "https://bootstrap.example.com"
+      },
+      body: JSON.stringify(payload)
+    });
+
+    const env = { SIGNING_SECRET: "test-secret" };
+    const response = await workerModule.default.fetch(request, env, {
+      waitUntil: () => {}
+    });
+
+    assert.equal(response.status, 200);
+    const json = await response.json();
+    assert.equal(json.success, true);
+    assert.equal(typeof json.token, "string");
+
+    const decoded = await verifyToken(env, json.token);
+    assert.equal(decoded?.plan?.src.startsWith("https://ads.example.com"), true);
+  });
+});
+
+test("bootstrap respects path segment in domain rule", { concurrency: false }, async () => {
+  await withSupabaseStub((table) => {
+    if (table === "campaigns") {
+      return {
+        select: () => ({
+          order: async () => ({
+            data: [
+              {
+                id: "cmp-path",
+                status: true,
+                audience_rules: { domain: "publisher.example/offers" },
+                ad_url: "https://ads.example.com/path?rid={{_r}}",
+                iframe_width: 160,
+                iframe_height: 600,
+                iframe_style: null,
+                iframe_attributes: null
+              }
+            ],
+            error: null
+          })
+        })
+      };
+    }
+
+    if (table === "events") {
+      return {
+        insert: async () => ({ error: null })
+      };
+    }
+
+    throw new Error(`Unexpected table: ${table}`);
+  }, async () => {
+    const payload = { u: "https://publisher.example/offers/welcome" };
+    const request = new Request("https://bootstrap.example.com/api", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Origin: "https://bootstrap.example.com"
+      },
+      body: JSON.stringify(payload)
+    });
+
+    const env = { SIGNING_SECRET: "test-secret" };
+    const response = await workerModule.default.fetch(request, env, {
+      waitUntil: () => {}
+    });
+
+    assert.equal(response.status, 200);
+    const json = await response.json();
+    assert.equal(json.success, true);
+    assert.equal(typeof json.token, "string");
+
+    const decoded = await verifyToken(env, json.token);
+    assert.equal(decoded?.plan?.src.includes("path?rid="), true);
+  });
+});
+
 test("bootstrap locates signing secret stored inside nested secrets bag", { concurrency: false }, async () => {
   await withSupabaseStub((table) => {
     if (table === "campaigns") {

--- a/functions/b.js
+++ b/functions/b.js
@@ -150,6 +150,90 @@ function inferDeviceType(ua = "") {
   return /mobile|android|iphone|ipad|ipod/i.test(ua) ? "Mobile" : "Desktop";
 }
 
+function tryParseUrl(value) {
+  if (typeof value !== "string" || value.trim() === "") {
+    return null;
+  }
+
+  try {
+    return new URL(value);
+  } catch (err) {
+    return null;
+  }
+}
+
+function normalizePath(path = "") {
+  if (typeof path !== "string") return "";
+  let normalized = path.trim();
+  if (!normalized || normalized === "/") return "";
+  if (!normalized.startsWith("/")) normalized = `/${normalized}`;
+  normalized = normalized.replace(/\/+$/, "");
+  return normalized === "" ? "" : normalized;
+}
+
+function normalizeDomainRule(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const candidates = [];
+  if (/^https?:\/\//i.test(trimmed)) {
+    candidates.push(trimmed);
+  } else {
+    candidates.push(`https://${trimmed}`);
+    candidates.push(trimmed);
+  }
+
+  for (const candidate of candidates) {
+    try {
+      const parsed = new URL(candidate);
+      const hostname = parsed.hostname?.toLowerCase();
+      if (!hostname) continue;
+      const path = normalizePath(parsed.pathname || "");
+      return { hostname, path };
+    } catch (err) {
+      // try next candidate
+    }
+  }
+
+  const withoutProtocol = trimmed.replace(/^[^/]*:\/\//, "");
+  const [hostPart = "", ...pathParts] = withoutProtocol.split("/");
+  const hostname = hostPart.toLowerCase();
+  if (!hostname) return null;
+  const path = normalizePath(pathParts.join("/"));
+  return { hostname, path };
+}
+
+function matchesDomainRule(pageUrl, domainRule) {
+  const normalizedRule = normalizeDomainRule(domainRule);
+  if (!normalizedRule) return false;
+
+  const parsedPage = tryParseUrl(pageUrl);
+  if (!parsedPage) {
+    if (typeof pageUrl === "string" && pageUrl.trim() !== "") {
+      return pageUrl.startsWith(domainRule);
+    }
+    return false;
+  }
+
+  const pageHostname = parsedPage.hostname?.toLowerCase();
+  if (!pageHostname) return false;
+
+  const { hostname: ruleHost, path: rulePath } = normalizedRule;
+  const hostMatches =
+    pageHostname === ruleHost || pageHostname.endsWith(`.${ruleHost}`);
+  if (!hostMatches) return false;
+
+  if (rulePath) {
+    const pagePath = parsedPage.pathname || "/";
+    if (!(pagePath === rulePath || pagePath.startsWith(`${rulePath}/`))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 async function selectAdPlan(pageUrl = "", retargetId) {
   try {
     const { data, error } = await supabase
@@ -177,7 +261,7 @@ async function selectAdPlan(pageUrl = "", retargetId) {
           continue;
         }
       } else if (domainRule && typeof domainRule === "string") {
-        if (!url.startsWith(domainRule)) continue;
+        if (!matchesDomainRule(url, domainRule)) continue;
       }
 
       const adUrl = typeof row.ad_url === "string"


### PR DESCRIPTION
## Summary
- normalize campaign domain rules so the bootstrap handler matches publisher URLs by hostname and optional path segments
- retain the legacy prefix fallback when the publisher URL cannot be parsed
- add automated tests covering subdomain and path-based audience domain rules

## Testing
- node --test functions/__tests__/b.test.js

------
https://chatgpt.com/codex/tasks/task_b_68e3a5acf4648323bdb29ec439ba842e