### PR TITLE
Ensure bootstrap frame stays hidden by default

### DIFF
--- a/functions/__tests__/b.test.js
+++ b/functions/__tests__/b.test.js
@@ -89,6 +89,180 @@ test("bootstrap response includes frame_src with token when ad plan found", { co
   });
 });
 
+test("bootstrap default iframe style keeps frame hidden when not provided", { concurrency: false }, async () => {
+  await withSupabaseStub((table) => {
+    if (table === "campaigns") {
+      return {
+        select: () => ({
+          order: async () => ({
+            data: [
+              {
+                id: "cmp-hidden",
+                status: true,
+                ad_url: "https://ads.example.com/render?rid={{_r}}",
+                iframe_width: null,
+                iframe_height: null,
+                iframe_style: null,
+                iframe_attributes: null
+              }
+            ],
+            error: null
+          })
+        })
+      };
+    }
+
+    if (table === "events") {
+      return {
+        insert: async () => ({ error: null })
+      };
+    }
+
+    throw new Error(`Unexpected table: ${table}`);
+  }, async () => {
+    const request = new Request("https://bootstrap.example.com/api", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Origin: "https://bootstrap.example.com",
+        Cookie: ""
+      },
+      body: JSON.stringify({})
+    });
+
+    const env = { SIGNING_SECRET: "test-secret" };
+
+    const response = await workerModule.default.fetch(request, env, {
+      waitUntil: () => {}
+    });
+
+    assert.equal(response.status, 200);
+    const json = await response.json();
+    assert.equal(typeof json.token, "string");
+
+    const decoded = await verifyToken(env, json.token);
+    assert.equal(
+      decoded?.plan?.style.includes("visibility:hidden"),
+      true,
+      "default iframe style keeps the bootstrap frame hidden"
+    );
+  });
+});
+
+test("bootstrap matches campaigns by domain rule on subdomains", { concurrency: false }, async () => {
+  await withSupabaseStub((table) => {
+    if (table === "campaigns") {
+      return {
+        select: () => ({
+          order: async () => ({
+            data: [
+              {
+                id: "cmp-789",
+                status: true,
+                audience_rules: { domain: "publisher.example" },
+                ad_url: "https://ads.example.com/render?rid={{_r}}",
+                iframe_width: 728,
+                iframe_height: 90,
+                iframe_style: null,
+                iframe_attributes: null
+              }
+            ],
+            error: null
+          })
+        })
+      };
+    }
+
+    if (table === "events") {
+      return {
+        insert: async () => ({ error: null })
+      };
+    }
+
+    throw new Error(`Unexpected table: ${table}`);
+  }, async () => {
+    const payload = { u: "https://sub.publisher.example/articles?id=1" };
+    const request = new Request("https://bootstrap.example.com/api", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Origin: "https://bootstrap.example.com"
+      },
+      body: JSON.stringify(payload)
+    });
+
+    const env = { SIGNING_SECRET: "test-secret" };
+    const response = await workerModule.default.fetch(request, env, {
+      waitUntil: () => {}
+    });
+
+    assert.equal(response.status, 200);
+    const json = await response.json();
+    assert.equal(json.success, true);
+    assert.equal(typeof json.token, "string");
+
+    const decoded = await verifyToken(env, json.token);
+    assert.equal(decoded?.plan?.src.startsWith("https://ads.example.com"), true);
+  });
+});
+
+test("bootstrap respects path segment in domain rule", { concurrency: false }, async () => {
+  await withSupabaseStub((table) => {
+    if (table === "campaigns") {
+      return {
+        select: () => ({
+          order: async () => ({
+            data: [
+              {
+                id: "cmp-path",
+                status: true,
+                audience_rules: { domain: "publisher.example/offers" },
+                ad_url: "https://ads.example.com/path?rid={{_r}}",
+                iframe_width: 160,
+                iframe_height: 600,
+                iframe_style: null,
+                iframe_attributes: null
+              }
+            ],
+            error: null
+          })
+        })
+      };
+    }
+
+    if (table === "events") {
+      return {
+        insert: async () => ({ error: null })
+      };
+    }
+
+    throw new Error(`Unexpected table: ${table}`);
+  }, async () => {
+    const payload = { u: "https://publisher.example/offers/welcome" };
+    const request = new Request("https://bootstrap.example.com/api", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Origin: "https://bootstrap.example.com"
+      },
+      body: JSON.stringify(payload)
+    });
+
+    const env = { SIGNING_SECRET: "test-secret" };
+    const response = await workerModule.default.fetch(request, env, {
+      waitUntil: () => {}
+    });
+
+    assert.equal(response.status, 200);
+    const json = await response.json();
+    assert.equal(json.success, true);
+    assert.equal(typeof json.token, "string");
+
+    const decoded = await verifyToken(env, json.token);
+    assert.equal(decoded?.plan?.src.includes("path?rid="), true);
+  });
+});
+
 test("bootstrap locates signing secret stored inside nested secrets bag", { concurrency: false }, async () => {
   await withSupabaseStub((table) => {
     if (table === "campaigns") {


### PR DESCRIPTION
## Summary
- normalize campaign domain rules so the bootstrap handler matches publisher URLs by hostname and optional path segments
- retain the legacy prefix fallback when the publisher URL cannot be parsed
- add automated tests covering subdomain and path-based audience domain rules
- ensure the default iframe style keeps the bootstrap frame hidden so the user sees no visual change

## Testing
- node --test functions/__tests__/b.test.js

------
https://chatgpt.com/codex/tasks/task_b_68e3a5acf4648323bdb29ec439ba842e