### PR TITLE
Handle Supabase string status flags as active campaigns

### DIFF
--- a/functions/__tests__/b.test.js
+++ b/functions/__tests__/b.test.js
@@ -89,6 +89,63 @@ test("bootstrap response includes frame_src with token when ad plan found", { co
   });
 });
 
+test("bootstrap treats truthy string status as active", { concurrency: false }, async () => {
+  await withSupabaseStub((table) => {
+    if (table === "campaigns") {
+      return {
+        select: () => ({
+          order: async () => ({
+            data: [
+              {
+                id: "cmp-string-status",
+                status: "TRUE",
+                audience_rules: { domain: "comhoma.com/cart" },
+                ad_url: "https://ads.example.com/render",
+                iframe_width: 300,
+                iframe_height: 250,
+                iframe_style: null,
+                iframe_attributes: null
+              }
+            ],
+            error: null
+          })
+        })
+      };
+    }
+
+    if (table === "events") {
+      return {
+        insert: async () => ({ error: null })
+      };
+    }
+
+    throw new Error(`Unexpected table: ${table}`);
+  }, async () => {
+    const payload = { u: "https://comhoma.com/cart" };
+    const request = new Request("https://bootstrap.example.com/api", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Origin: "https://bootstrap.example.com"
+      },
+      body: JSON.stringify(payload)
+    });
+
+    const env = { SIGNING_SECRET: "test-secret" };
+    const response = await workerModule.default.fetch(request, env, {
+      waitUntil: () => {}
+    });
+
+    assert.equal(response.status, 200);
+    const json = await response.json();
+    assert.equal(json.success, true);
+
+    const decoded = await verifyToken(env, json.token);
+    assert.equal(decoded?.plan?.src, "https://ads.example.com/render");
+    assert.equal(decoded?.plan?.campaignId, "cmp-string-status");
+  });
+});
+
 test("bootstrap matches campaigns by domain rule on subdomains", { concurrency: false }, async () => {
   await withSupabaseStub((table) => {
     if (table === "campaigns") {

--- a/functions/b.js
+++ b/functions/b.js
@@ -70,6 +70,26 @@ function normalizeAttributes(attributes) {
   return normalized;
 }
 
+function isActiveStatus(value) {
+  if (value === true) return true;
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) return false;
+    return ["true", "t", "1", "yes", "y"].includes(normalized);
+  }
+
+  if (typeof value === "number") {
+    return value === 1;
+  }
+
+  if (typeof value === "bigint") {
+    return value === 1n;
+  }
+
+  return false;
+}
+
 function generateNonce() {
   if (typeof crypto !== "undefined" && crypto.getRandomValues) {
     const bytes = new Uint8Array(16);
@@ -247,7 +267,7 @@ async function selectAdPlan(pageUrl = "", retargetId) {
 
     const url = pageUrl || "";
     for (const row of data) {
-      if (!row || row.status !== true) continue;
+      if (!row || !isActiveStatus(row.status)) continue;
 
       const rules = row.audience_rules || {};
       const regexRule = rules.regex;


### PR DESCRIPTION
## Summary
- treat truthy Supabase status values as active when selecting a campaign plan
- cover string status handling with a bootstrap regression test

## Testing
- node --test functions/__tests__/b.test.js

------
https://chatgpt.com/codex/tasks/task_b_68e3ab4fd53c8323bf8533673acde3ca