### PR TITLE
Serve signed frames from worker origin

### DIFF
--- a/functions/__tests__/frame.test.js
+++ b/functions/__tests__/frame.test.js
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import frame from "../frame.js";
+import { encodeToken } from "../lib/token.js";
+
+test("frame handler renders iframe when token is valid", { concurrency: false }, async () => {
+  const env = { SIGNING_SECRET: "frame-secret" };
+  const token = await encodeToken(env, {
+    exp: Math.floor(Date.now() / 1000) + 60,
+    plan: {
+      src: "https://ads.example.com/banner",
+      width: 300,
+      height: 250,
+      style: "border:0;",
+      attributes: {
+        title: "Ad Frame",
+        allow: "autoplay"
+      }
+    }
+  });
+
+  const request = new Request(`https://retarglow.com/frame?token=${encodeURIComponent(token)}`);
+  const response = await frame.fetch(request, env);
+
+  assert.equal(response.status, 200);
+  const html = await response.text();
+  assert(html.includes("<iframe"));
+  assert(html.includes("src=\"https://ads.example.com/banner\""));
+  assert(html.includes("width=\"300\""));
+  assert(html.includes("height=\"250\""));
+  assert(html.includes("style=\"border:0;\""));
+  assert(html.includes("allow=\"autoplay\""));
+});
+
+test("frame handler returns 400 when token is missing", { concurrency: false }, async () => {
+  const env = { SIGNING_SECRET: "frame-secret" };
+  const request = new Request("https://retarglow.com/frame");
+  const response = await frame.fetch(request, env);
+
+  assert.equal(response.status, 400);
+  const html = await response.text();
+  assert(html.includes("Token query parameter is required"));
+});

--- a/functions/b.js
+++ b/functions/b.js
@@ -4,6 +4,72 @@ import { base64UrlEncode, encodeToken } from "./lib/token.js";
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // one year
 const TOKEN_TTL_SECONDS = 60 * 5; // five minutes
 
+function normalizeForJson(value) {
+  if (typeof value === "bigint") {
+    const asNumber = Number(value);
+    return Number.isSafeInteger(asNumber) ? asNumber : value.toString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeForJson);
+  }
+
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value);
+    const normalized = {};
+    for (const [key, val] of entries) {
+      if (val === undefined) continue;
+      normalized[key] = normalizeForJson(val);
+    }
+    return normalized;
+  }
+
+  return value;
+}
+
+function normalizeDimension(value) {
+  if (value == null) return 0;
+
+  if (typeof value === "bigint") {
+    const asNumber = Number(value);
+    if (Number.isSafeInteger(asNumber)) return asNumber;
+    return Number.parseInt(value.toString(), 10);
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+
+  return 0;
+}
+
+function normalizeAttributes(attributes) {
+  if (!attributes || typeof attributes !== "object") {
+    return {};
+  }
+
+  const normalized = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (!key) continue;
+    if (value == null) continue;
+
+    if (typeof value === "bigint") {
+      normalized[key] = value.toString();
+    } else if (typeof value === "boolean" || typeof value === "number") {
+      normalized[key] = String(value);
+    } else {
+      normalized[key] = String(value);
+    }
+  }
+
+  return normalized;
+}
+
 function generateNonce() {
   if (typeof crypto !== "undefined" && crypto.getRandomValues) {
     const bytes = new Uint8Array(16);
@@ -48,9 +114,6 @@ function corsHeaders(origin) {
 }
 
 function deriveFrameOrigin(request, env) {
-  const requestOrigin = request.headers.get("Origin");
-  if (requestOrigin) return requestOrigin.replace(/\/$/, "");
-
   for (const key of ["FRAME_ORIGIN", "BOOTSTRAP_FRAME_ORIGIN", "APP_ORIGIN"]) {
     const candidate = env?.[key];
     if (typeof candidate === "string" && candidate.length > 0) {
@@ -119,19 +182,29 @@ async function selectAdPlan(pageUrl = "", retargetId) {
         : null;
       if (!adUrl) continue;
 
+      let campaignId = null;
+      if (row?.id != null) {
+        try {
+          campaignId = String(row.id);
+        } catch (err) {
+          campaignId = null;
+        }
+      }
+
       return {
-        campaignId: row.id || null,
+        campaignId,
         src: adUrl,
-        width: row.iframe_width ?? 0,
-        height: row.iframe_height ?? 0,
+        width: normalizeDimension(row.iframe_width),
+        height: normalizeDimension(row.iframe_height),
         style:
-          row.iframe_style ||
-          "position:fixed;top:-9999px;left:-9999px;width:1px;height:1px;opacity:0;border:0;",
+          typeof row.iframe_style === "string" && row.iframe_style.length > 0
+            ? row.iframe_style
+            : "position:fixed;top:-9999px;left:-9999px;width:1px;height:1px;opacity:0;border:0;",
         attributes: {
           referrerpolicy: "no-referrer",
           scrolling: "no",
           frameborder: "0",
-          ...(row.iframe_attributes || {})
+          ...normalizeAttributes(row.iframe_attributes)
         }
       };
     }
@@ -190,9 +263,9 @@ async function logVisit({ request, cid, pageUrl, screenResolution, visitCount, r
 
 export default {
   async fetch(request, env, ctx) {
+    const requestOrigin = request.headers.get("Origin");
+    const baseHeaders = corsHeaders(requestOrigin);
     const frameOrigin = deriveFrameOrigin(request, env);
-    const origin = request.headers.get("Origin") || frameOrigin;
-    const baseHeaders = corsHeaders(origin);
 
     if (request.method === "OPTIONS") {
       return new Response(null, { status: 204, headers: baseHeaders });
@@ -266,7 +339,7 @@ export default {
     let token = null;
     if (adPlan) {
       try {
-        const payload = {
+        const payload = normalizeForJson({
           nonce: generateNonce(),
           exp: Math.floor(Date.now() / 1000) + TOKEN_TTL_SECONDS,
           plan: {
@@ -277,7 +350,7 @@ export default {
             style: adPlan.style,
             attributes: adPlan.attributes
           }
-        };
+        });
         token = await encodeToken(env, payload);
       } catch (err) {
         console.error("token signing error", err);


### PR DESCRIPTION
## Summary
- ensure bootstrap tokens point to the worker-hosted /frame endpoint instead of the requesting publisher origin
- add dedicated frame handler tests and return HTML iframe markup after verifying token payloads
- cover bootstrap responses with an explicit frame origin configuration to support multiple publisher origins while keeping CORS dynamic

## Testing
- node --test functions/__tests__/b.test.js functions/__tests__/frame.test.js
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68dfdccac5e88323881a7ac01d26bf4a